### PR TITLE
Added Jinja2 wrapping to with_items

### DIFF
--- a/roles/provision-ec2/tasks/main.yml
+++ b/roles/provision-ec2/tasks/main.yml
@@ -21,7 +21,7 @@
    register: ec2
 
  - debug: var=item
-   with_items: ec2.instances
+   with_items: "{{ ec2.instances }}"
 
  - add_host: name={{ item.public_ip }} >
              groups=tag_Type_{{ec2_tag_Type}},tag_Environment_{{ec2_tag_Environment}}
@@ -30,8 +30,8 @@
              ec2_tag_Type={{ec2_tag_Type}}
              ec2_tag_Environment={{ec2_tag_Environment}}
              ec2_ip_address={{item.public_ip}}
-   with_items: ec2.instances
+   with_items: "{{ ec2.instances }}"
 
  - name: Wait for the instances to boot by checking the ssh port
    wait_for: host={{item.public_ip}} port=22 delay=60 timeout=320 state=started
-   with_items: ec2.instances
+   with_items: "{{ ec2.instances }}"


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

I found your blog really helpful but had some teething problems with the parts beyond the provision task.  I tracked this down to a change in Ansible since v2.2 (long since the blog was published) which means that `with_items` requires explicit jinja2 wrapping.

I've applied those changes within this PR in case it helps someone else.
